### PR TITLE
hotfix: classes without basemodel inherit

### DIFF
--- a/src/models/models.py
+++ b/src/models/models.py
@@ -54,7 +54,7 @@ class Invoice(BaseModel):
     card_id: Optional[int] = None
 
 
-class Pix:
+class Pix(BaseModel):
     pix_key_type: PixType
     pix_key: str
     bank_account_id: Optional[int] = None

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -27,7 +27,7 @@ class Bank(BaseModel):
     account_id: Optional[int] = None
 
 
-class BankAccount:
+class BankAccount(BaseModel):
     variation: int = 0
     number: str
     type_account: BankAccountType

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -35,7 +35,7 @@ class BankAccount(BaseModel):
     bank_id: Optional[int] = None
 
 
-class Card:
+class Card(BaseModel):
     name: str
     number: str
     due_date: date

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -45,7 +45,7 @@ class Card(BaseModel):
     bank_account_id: Optional[int] = None
 
 
-class Invoice:
+class Invoice(BaseModel):
     total_invoice: Decimal
     installments: int
     installments_value: Decimal


### PR DESCRIPTION
- fix: basemodel to bank account
- fix: basemodel to card
- fix: basemodel to invoice
- fix: basemodel to pix

I fixed all classes models without inherit from `BaseModel`.
