### PR TITLE
hotfix: transfer pix extends from basemodel

### DIFF
--- a/src/models/models.py
+++ b/src/models/models.py
@@ -60,7 +60,7 @@ class Pix(BaseModel):
     bank_account_id: Optional[int] = None
 
 
-class TransferPix:
+class TransferPix(BaseModel):
     send_pix_type: PixType
     receiver_pix_type: PixType
     is_yours: bool = False


### PR DESCRIPTION
I added `BaseModel` as TransferPix superclass.﻿
